### PR TITLE
Ensure cross-site auth tokens for protected routes

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -124,9 +124,18 @@ export const login = catchAsynError(async (req, res, next) => {
 // Logout controller
 export const logout = catchAsynError(async (req, res, next) => {
   try {
-    // Remove the token from the response header
-    res.clearCookie("token");
-    res.status(200).json({ success: true, message: "User logged out" });
+    const isProduction = process.env.NODE_ENV === "production";
+
+    // Clear the authentication cookie
+    res
+      .status(200)
+      .cookie("token", "", {
+        expires: new Date(0),
+        httpOnly: true,
+        secure: isProduction,
+        sameSite: "none",
+      })
+      .json({ success: true, message: "User logged out" });
   } catch (error) {
     console.error("An error occurred:", error.message);
     return next(new ErrorHandler(500, "Internal Server Error"));
@@ -136,7 +145,6 @@ export const logout = catchAsynError(async (req, res, next) => {
 // Get user for admin dashboard -> authentication required
 export const getUser = catchAsynError(async (req, res, next) => {
   try {
-    console.log(req.user._id);
     const user = await User.findById(req.user._id);
     if (!user) {
       return next(new ErrorHandler(404, "User not found"));

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -5,7 +5,15 @@ import jwt from "jsonwebtoken";
 
 // Authenticate user
 export const authenticateUser = catchAsynError(async (req, res, next) => {
-  const token = req.cookies.token;
+  // Try to retrieve token from cookies or Authorization header
+  let token = req.cookies.token;
+
+  if (!token && req.headers.authorization) {
+    const authHeader = req.headers.authorization;
+    token = authHeader.startsWith("Bearer ")
+      ? authHeader.slice(7)
+      : authHeader;
+  }
 
   if (!token) {
     return next(new ErrorHandler(401, "User not authenticated"));

--- a/utils/jwtToken.js
+++ b/utils/jwtToken.js
@@ -6,14 +6,16 @@ export const generateToken = async (user, message, statusCode, res) => {
       expiresIn: "10h", // Token expires in 10 hours
     });
 
+    const isProduction = process.env.NODE_ENV === "production";
+
     // Configure the cookie with cross-origin support and secure settings
     res
       .status(statusCode)
       .cookie("token", token, {
         expires: new Date(Date.now() + 10 * 60 * 60 * 1000), // 10 hours expiration
         httpOnly: true, // Prevents JavaScript from accessing the cookie (for security)
-        secure: process.env.NODE_ENV === "production", // Set to true in production (requires HTTPS)
-        sameSite: "lax", // 'none' for cross-site requests in production
+        secure: isProduction, // Send cookie only over HTTPS in production
+        sameSite: "none", // Always allow cross-site cookies
       })
       .json({ success: true, message, user, token });
   } catch (error) {


### PR DESCRIPTION
## Summary
- allow Authorization header token without a Bearer prefix
- always set auth cookies with `sameSite: "none"` for cross-origin requests
- drop debug logging from user retrieval handler

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a216ede3308328b5d9d8ad53c6ad22